### PR TITLE
#145 Added restrict_path on TOC+

### DIFF
--- a/toc.php
+++ b/toc.php
@@ -174,7 +174,7 @@ if ( !class_exists( 'toc' ) ) :
 				'exclude_css' => false,
 				'exclude' => '',
 				'heading_levels' => array('1', '2', '3', '4', '5', '6'),
-				'restrict_path' => '',
+				'restrict_path' => '/docs/',
 				'css_container_class' => '',
 				'sitemap_show_page_listing' => true,
 				'sitemap_show_category_listing' => true,


### PR DESCRIPTION
Caldrà executar el següent 'update' al portal per a tots els centres, ja que he comprovat que hi han centres amb aquesta variable buida. 

UPDATE `wp_options` SET `option_value`=REPLACE(`option_value`, 's:13:"restrict_path";s:0:"";','s:13:"restrict_path";s:6:"/docs/";') 
WHERE `option_name`='toc-options';